### PR TITLE
Updating behaviour for placing views

### DIFF
--- a/Modular/Classes/Extensions/Place+Basic.swift
+++ b/Modular/Classes/Extensions/Place+Basic.swift
@@ -85,7 +85,6 @@ extension Place where T: ViewAlias {
         }
         superview.addSubview(element)
         element.snp.makeConstraints { (make) in
-            make.top.equalTo(view.snp.top)
             make.left.equalTo(view.snp.right).offset(left)
             set(width: width, height: height, on: make)
         }
@@ -98,7 +97,6 @@ extension Place where T: ViewAlias {
         }
         superview.addSubview(element)
         element.snp.makeConstraints { (make) in
-            make.top.equalTo(view.snp.top)
             make.right.equalTo(view.snp.left).offset(right)
             set(width: width, height: height, on: make)
         }
@@ -111,7 +109,6 @@ extension Place where T: ViewAlias {
         }
         superview.addSubview(element)
         element.snp.makeConstraints { (make) in
-            make.top.equalTo(view1.snp.top).offset(top)
             make.left.equalTo(view1.snp.right).offset(left)
             make.right.equalTo(view2.snp.left).offset(right)
             set(width: width, height: height, on: make)


### PR DESCRIPTION
Removing the top constraint when placing a view next to, before, or between views as it can cause odd effects when adding additional effects (`centerY` for example)

These functions should place the view in the correct place along the X-axis, without affecting the Y-axis. Placement on the Y-axis should be left up to the user to handle.